### PR TITLE
Migrated to AndroidX and updated compileSdkVersion

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,14 +3,14 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     defaultConfig {
         applicationId "com.clusterrr.hardwarekeyboard"
-        minSdkVersion 28
-        targetSdkVersion 28
+        minSdkVersion 19
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
         release {
@@ -22,11 +22,11 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 repositories {

--- a/app/src/main/java/com/clusterrr/hardwarekeyboard/CluKeyboard.kt
+++ b/app/src/main/java/com/clusterrr/hardwarekeyboard/CluKeyboard.kt
@@ -357,9 +357,9 @@ class CluKeyboard : InputMethodService(), View.OnClickListener, CompoundButton.O
         updateInputViewShown()
         val current = isInputViewShown
         if (!current)
-            requestShowSelf(0)
+            showWindow(true)
         else
-            requestHideSelf(0)
+            hideWindow()
     }
 
     private fun adjustBrightness(delta: Int) {

--- a/app/src/main/res/layout/keyboard_layout.xml
+++ b/app/src/main/res/layout/keyboard_layout.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -45,4 +45,4 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,8 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
+android.enableJetifier=true
+android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
Support libraries is deprecated now, so we need to migrate to AndroidX.
Also I updated `compileSdkVersion` and `targetSdkVersion` to latest Android 10. And `minSdkVersion` I set to Android 4.4. 
Tested on my 4.4 device, keyboard seems working well even on that old device, so there is no need to limit only for Android 9. The only issue is that switches is using old design, but I think if needed it might be changed later to SwitchCompat.
![image](https://user-images.githubusercontent.com/9720950/70715597-4b0d1280-1cf3-11ea-83d2-1cf054da8ad4.png)
